### PR TITLE
Extract rpm installation logic into its own role

### DIFF
--- a/local_artifact/README.md
+++ b/local_artifact/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+local_artifact
+==============
 
 An Ansible role for uploading an artifact from the local system. The main benefit of this role to pair with the
 the ```repository_artifact``` role in a when clause to use either a "released" artifact from a repository or a local artifact.

--- a/nifi/README.md
+++ b/nifi/README.md
@@ -6,15 +6,19 @@ Use this role to install, configure, and manage Apache NiFi.
 Requirements
 ------------
 
-- Role has only been tested with CentOS 7.
-- Role installs NiFi via rpm, and the rpm file must be accssible on the target system prior to executing this role
+- NiFi distribution must be accssible on the target system prior to executing this role
+  - if RPM, the RPM must be installed
+  - if tar.gz, it must be unarchived
 
 Role Variables
 --------------
 
-### Variables that must be overridden are:
-    nifi_rpm_file: location of the rpm file to be installed
-    nifi_install_rpm: boolean controls whether to update the rpm install or not, defaults to True
+### Variables that determine the nifi install location, and their default values:
+
+    nifi_base_dir: /var/lib/nifi
+    nifi_etc_dir: /etc/nifi
+    nifi_log_dir: /var/log/nifi
+    nifi_pid_dir: /var/run/nifi
 
 ### Other Default variables are listed below:
     # A complete list of IP addresses for each nodes within the nifi cluster

--- a/nifi/defaults/main.yml
+++ b/nifi/defaults/main.yml
@@ -1,4 +1,12 @@
 ---
+# defaults file for nifi
+
+# installation locations
+nifi_base_dir: /var/lib/nifi
+nifi_etc_dir: /etc/nifi
+nifi_log_dir: /var/log/nifi
+nifi_pid_dir: /var/run/nifi
+
 # A complete list of IP addresses for each nodes within the nifi cluster
 nifi_nodes_list: []
 

--- a/nifi/tasks/install.yml
+++ b/nifi/tasks/install.yml
@@ -1,14 +1,7 @@
 ---
 # tasks file for nifi
 
-# cannot use yum to install rpm because it will never upgrade (https://github.com/ansible/ansible-modules-core/issues/4529)
-- name: Install nifi via rpm
-  command: "rpm --nosignature -U {{ nifi_rpm_file }}"
-  when: "{{ nifi_install_rpm | default(True) }}"
-  notify:
-    - restart nifi
-
-- name: Ensure files created by nifi rpm are world-readable
+- name: Ensure nifi files are world-readable
   file: path="{{ nifi_base_dir }}" state=directory mode="a+rX" recurse=yes
 
 - name: Ensure nifi symlink
@@ -24,7 +17,7 @@
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7"
   tags: [ service ]
 
-- name: copy startup script
+- name: Create nifi init.d service
   template: src=nifi-startup.sh.j2 dest=/etc/init.d/nifi owner=root group=root mode=0755
   when: ansible_distribution == "Amazon" or (ansible_distribution == "CentOS" and ansible_distribution_major_version < "7")
   tags: [ service ]

--- a/nifi/vars/main.yml
+++ b/nifi/vars/main.yml
@@ -4,12 +4,8 @@
 nifi_user: nifi
 nifi_service: /etc/systemd/system/nifi.service
 
-nifi_base_dir: /var/lib/nifi
 nifi_home: "{{ nifi_base_dir }}/nifi-current"
 nifi_conf_dir: "{{ nifi_home }}/conf"
 nifi_nar_dir: "{{ nifi_home }}/lib"
 nifi_work_dir: "{{ nifi_home }}/work"
-nifi_etc_dir: /etc/nifi
-nifi_log_dir: /var/log/nifi
-nifi_pid_dir: /var/run/nifi
 nifi_pid_file: "{{ nifi_pid_dir }}/nifi.pid"

--- a/nifi_nars/tasks/main.yml
+++ b/nifi_nars/tasks/main.yml
@@ -2,23 +2,19 @@
 # tasks file for nifi_nars
 
 - name: Ensure required directories exist
-  file: path="{{ nifi_nars_base_dir }}" state=directory owner="{{ nifi_nars_user }}" group="{{ nifi_nars_group }}" mode=0755
-  tags: [ install ]
-
-# cannot use yum to install rpm because it will never upgrade (https://github.com/ansible/ansible-modules-core/issues/4529)
-- name: Install nars via rpm
-  command: "rpm --nosignature -U {{ nifi_nars_rpm }}"
-  notify:
-    - restart nifi
-  tags: [ install ]
+  file:
+    path: "{{ nifi_nars_base_dir }}"
+    state: directory
+    owner: "{{ nifi_nars_user }}"
+    group: "{{ nifi_nars_group }}"
+    mode: 0755
 
 - name: Ensure symlink
   file: src="{{ nifi_nars_base_dir }}/{{ nifi_nars_dir }}" dest="{{ nifi_nars_symlink }}" state=link
   notify:
     - restart nifi
-  tags: [ install ]
 
-- name: Update nifi configs
+- name: Ensure nars are configured in nifi.properties
   lineinfile:
     dest: "{{ nifi_conf_dir }}/nifi.properties"
     state: present
@@ -27,5 +23,4 @@
     insertafter: "^nifi.nar.library.directory="
   notify:
     - restart nifi
-  tags: [ config ]
 

--- a/rpm_install/README.md
+++ b/rpm_install/README.md
@@ -1,0 +1,37 @@
+rpm_install
+===========
+
+This Ansible role installs an RPM from a file. Role calls the rom command directly rather than using yum so that snapshotted
+rpm's are able to be updated.
+
+Requirements
+------------
+
+Naturally, role assumes an RPM-based distro.
+
+Role Variables
+--------------
+
+Optional variables:
+
+    rpm_nosignature - if True, enables rpm ```--nosignature``` flag to not verify package or header signatures
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+See [nifi_nars/README.md](../nifi_nars/README.md) for a complete example.
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+[Asymmetrik, Ltd.](https://www.asymmetrik.com/)

--- a/rpm_install/tasks/main.yml
+++ b/rpm_install/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# tasks file for rpm_install
+
+# cannot use yum to install rpm because it will never upgrade (https://github.com/ansible/ansible-modules-core/issues/4529)
+- name: Install rpm
+  command: "rpm {{ (rpm_nosignature is True | ternary('--nosignature','') }} -U {{ rpm_path }}"
+

--- a/rpm_install/tasks/main.yml
+++ b/rpm_install/tasks/main.yml
@@ -3,5 +3,5 @@
 
 # cannot use yum to install rpm because it will never upgrade (https://github.com/ansible/ansible-modules-core/issues/4529)
 - name: Install rpm
-  command: "rpm {{ (rpm_nosignature is True | ternary('--nosignature','') }} -U {{ rpm_path }}"
+  command: "rpm {{ (rpm_nosignature) | ternary('--nosignature','') }} -U {{ rpm_path }}"
 

--- a/rpm_install/tests/inventory
+++ b/rpm_install/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/rpm_install/tests/test.yml
+++ b/rpm_install/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - rpm_install


### PR DESCRIPTION
Extract rpm installation logic into its own role. This makes it easier to skip rpm installation if the rpm has not changed, while still executing the configure portions. This would also allow the nifi & nifi_nars roles to be used with tar.gz's where needed.