### PR TITLE
Removed nifi's restart handler

### DIFF
--- a/nifi/tasks/config.yml
+++ b/nifi/tasks/config.yml
@@ -4,8 +4,6 @@
   with_items:
     - { src: 'nifi.properties.j2', dest: "{{nifi_conf_dir}}/nifi.properties" }
     - { src: 'extra-args.properties.j2', dest: "{{nifi_conf_dir}}/extra-args.properties" }
-  notify:
-    - restart nifi
   tags: [ deploy, prop, props ]
 
 - name: copy nifi configs
@@ -18,8 +16,6 @@
     - { src: 'login-identity-providers.xml.j2', dest: "{{nifi_conf_dir}}/login-identity-providers.xml" }
     - { src: 'state-management.xml.j2', dest: "{{nifi_conf_dir}}/state-management.xml" }
     - { src: 'zookeeper.properties.j2', dest: "{{nifi_conf_dir}}/zookeeper.properties" }
-  notify:
-    - restart nifi
   tags: [ config ]
 
 - name: copy nifi scripts

--- a/nifi/tasks/install.yml
+++ b/nifi/tasks/install.yml
@@ -6,14 +6,11 @@
 
 - name: Ensure nifi symlink
   file: src="{{ nifi_base_dir }}/nifi-{{ versions.nifi }}" dest="{{ nifi_home }}" state=link
-  notify:
-    - restart nifi
 
 - name: Create nifi systemd service
   template: src=nifi.service.j2 dest="{{ nifi_service }}" owner=root group=root mode=0644
   notify:
     - reload systemctl
-    - restart nifi
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7"
   tags: [ service ]
 

--- a/nifi/tasks/install.yml
+++ b/nifi/tasks/install.yml
@@ -51,11 +51,11 @@
 
 - name: ensure zookeeper data directory exists
   file: path="{{ nifi_zookeeper_dir }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
-  when: "{{ nifi_state_management_embedded_zookeeper_start }}"
+  when: nifi_state_management_embedded_zookeeper_start
 
 - name: add myid file for embedded zookeeper
   template: src="myid.j2" dest="{{ nifi_zookeeper_dir }}/myid" owner="{{ nifi_user }}" group="{{ nifi_user }}" mode='0644'
-  when: "{{ nifi_state_management_embedded_zookeeper_start }}"
+  when: nifi_state_management_embedded_zookeeper_start
 
 - name: ensure nifi extra directories exist
   file: path="{{ item }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755


### PR DESCRIPTION
Because this is a breaking change for existing nifi clusters in redwood, I removed nifi's restart handler until we figure out a better approach