### PR TITLE
InfluxDB and Grafana config updates for installation

### DIFF
--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
+download_from_s3: false
 grafana_version: 5.0.4
 grafana_app_mode: production
+grafana_filename: "grafana-{{ grafana_version }}-1.x86_64.rpm"
+grafana_dest: /tmp
 
 grafana_root_url: 'http://localhost:3000'
 grafana_admin_user: "admin"
@@ -11,3 +14,4 @@ grafana_log_level: 'info'
 
 grafana_external_image_storage_provider: ''
 grafana_external_image_storage_s3_bucket_url: ''
+

--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-grafana_retrieve_from_s3: false
+grafana_download: true
 grafana_version: 5.0.4
 grafana_app_mode: production
 grafana_filename: "grafana-{{ grafana_version }}-1.x86_64.rpm"

--- a/grafana/handlers/main.yml
+++ b/grafana/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart grafana
-  service: name=grafana state=restarted enabled=yes
+  service: name=grafana-server state=restarted enabled=yes

--- a/grafana/tasks/install.yml
+++ b/grafana/tasks/install.yml
@@ -6,16 +6,6 @@
     dest: "{{ grafana_dest }}"
     mode: 0755
 
-- name: Download Grafana from S3
-  when: download_from_s3 | default(false)
-  include_role:
-    name: get_s3
-  vars:
-    get_s3_src: "{{ grafana_filename }}"
-    get_s3_dest: "{{ grafana_dest }}/{{ grafana_filename }}"
-    get_s3_overwrite: different
-  tags: [ download ]
-
 - name: install grafana rpm from a local file
   yum:
     name: "{{ grafana_dest }}/{{ grafana_filename }}"

--- a/grafana/tasks/install.yml
+++ b/grafana/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download Grafana
-  when: grafana_download | default(true)
+  when: grafana_download
   get_url:
     url: "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-{{ grafana_version }}-1.x86_64.rpm"
     dest: "{{ grafana_dest }}"

--- a/grafana/tasks/install.yml
+++ b/grafana/tasks/install.yml
@@ -1,11 +1,22 @@
 ---
 - name: Download Grafana
+  when: not download_from_s3 | default(false)
   get_url:
     url: "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-{{ grafana_version }}-1.x86_64.rpm"
-    dest: /tmp
+    dest: "{{ grafana_dest }}"
     mode: 0755
+
+- name: Download Grafana from S3
+  when: download_from_s3 | default(false)
+  include_role:
+    name: get_s3
+  vars:
+    get_s3_src: "{{ grafana_filename }}"
+    get_s3_dest: "{{ grafana_dest }}/{{ grafana_filename }}"
+    get_s3_overwrite: different
+  tags: [ download ]
 
 - name: install grafana rpm from a local file
   yum:
-    name: "/tmp/grafana-{{ grafana_version }}-1.x86_64.rpm"
+    name: "{{ grafana_dest }}/{{ grafana_filename }}"
     state: present

--- a/grafana/tasks/install.yml
+++ b/grafana/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download Grafana
-  when: not grafana_retrieve_from_s3 | default(false)
+  when: grafana_download | default(true)
   get_url:
     url: "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-{{ grafana_version }}-1.x86_64.rpm"
     dest: "{{ grafana_dest }}"

--- a/influxdb/defaults/main.yml
+++ b/influxdb/defaults/main.yml
@@ -1,10 +1,14 @@
 ---
+download_from_s3: false
 influxdb_version: 1.5.1
 influxdb_meta_dir: "/var/lib/influxdb/meta"
 influxdb_data_dir: "/data"
 influxdb_index_version: "inmem"
 influxdb_wal_dir: "/var/lib/influxdb/wal"
+influxdb_lib_dir: "/var/lib/influxdb"
 influxdb_retention_check_interval: "30m"
 influxdb_http_log_enabled: true
 influxdb_max_select_point: 0
 influxdb_query_timeout: "0"
+influxdb_filename: "influxdb-{{ influxdb_version }}.x86_64.rpm"
+influxdb_dest: /tmp

--- a/influxdb/defaults/main.yml
+++ b/influxdb/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-influxdb_retrieve_from_s3: false
+influxdb_download: true
 influxdb_version: 1.5.1
 influxdb_meta_dir: "/var/lib/influxdb/meta"
 influxdb_data_dir: "/data"

--- a/influxdb/tasks/config.yml
+++ b/influxdb/tasks/config.yml
@@ -1,4 +1,15 @@
 ---
+- name: Update InfluxDB Directory Permissions
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ influxdb_user }}"
+    group: "{{ influxdb_user }}"
+    mode: "0755"
+  loop:
+    - "{{ influxdb_log_dir }}"
+    - "{{ influxdb_lib_dir }}"
+
 - name: copy startup scripts
   template: src="{{ item.src }}" dest="{{ item.dest }}" owner="root" group="root" mode='0755'
   with_items:

--- a/influxdb/tasks/install.yml
+++ b/influxdb/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download InfluxDB
-  when: influxdb_download | default(false)
+  when: influxdb_download
   get_url:
     url: "https://dl.influxdata.com/influxdb/releases/influxdb-{{ influxdb_version }}.x86_64.rpm"
     dest: "{{ influxdb_dest }}"

--- a/influxdb/tasks/install.yml
+++ b/influxdb/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download InfluxDB
-  when: not influxdb_retrieve_from_s3 | default(false)
+  when: influxdb_download | default(false)
   get_url:
     url: "https://dl.influxdata.com/influxdb/releases/influxdb-{{ influxdb_version }}.x86_64.rpm"
     dest: "{{ influxdb_dest }}"

--- a/influxdb/tasks/install.yml
+++ b/influxdb/tasks/install.yml
@@ -6,17 +6,6 @@
     dest: "{{ influxdb_dest }}"
     mode: 0755
 
-- name: Download InfluxDB from S3
-  when: download_from_s3 | default(false)
-  include_role:
-    name: get_s3
-  vars:
-    get_s3_src: "{{ influxdb_filename }}"
-    get_s3_dest: "{{ influxdb_dest }}/{{ influxdb_filename }}"
-    get_s3_overwrite: different
-  tags: [ download ]
-
-
 - name: install influx rpm from a local file
   yum:
     name: "{{ influxdb_dest }}/{{ influxdb_filename }}"

--- a/influxdb/tasks/install.yml
+++ b/influxdb/tasks/install.yml
@@ -1,11 +1,23 @@
 ---
 - name: Download InfluxDB
+  when: not download_from_s3 | default(false)
   get_url:
     url: "https://dl.influxdata.com/influxdb/releases/influxdb-{{ influxdb_version }}.x86_64.rpm"
-    dest: /tmp
+    dest: "{{ influxdb_dest }}"
     mode: 0755
+
+- name: Download InfluxDB from S3
+  when: download_from_s3 | default(false)
+  include_role:
+    name: get_s3
+  vars:
+    get_s3_src: "{{ influxdb_filename }}"
+    get_s3_dest: "{{ influxdb_dest }}/{{ influxdb_filename }}"
+    get_s3_overwrite: different
+  tags: [ download ]
+
 
 - name: install influx rpm from a local file
   yum:
-    name: "/tmp/influxdb-{{ influxdb_version }}.x86_64.rpm"
+    name: "{{ influxdb_dest }}/{{ influxdb_filename }}"
     state: present


### PR DESCRIPTION
Purpose: CODE

There have been a couple of edits to the ansible-role to be able to fetch from a S3 bucket where the RPMs reside if you set the download_from_s3 flag to be true (default is set to false).

Also edited a couple of the directories needed elevated privileges in order to start the services.