### PR TITLE
Service user dir optional

### DIFF
--- a/service_user/README.md
+++ b/service_user/README.md
@@ -16,13 +16,16 @@ Required variables:
     # user's name
     service_user_name:
 
-    # user's home directory
-    service_user_home:
-
 Optional variables and their default values:
 
     # user's group
     service_user_group: "{{ service_user_name }}"
+
+    # user's home directory (optional)
+    service_user_home:
+
+    # create user's home directory if it does not exist
+    service_user_create_home: true
 
 Example Playbook
 ----------------

--- a/service_user/README.md
+++ b/service_user/README.md
@@ -27,6 +27,8 @@ Optional variables and their default values:
     # create user's home directory if it does not exist
     service_user_create_home: true
 
+    service_user_home_permissions: 0755
+
 Example Playbook
 ----------------
 

--- a/service_user/defaults/main.yml
+++ b/service_user/defaults/main.yml
@@ -2,3 +2,6 @@
 # defaults file for service_user
 
 service_user_group: "{{ service_user_name }}"
+
+# create user's home directory if it does not exist
+service_user_create_home: true

--- a/service_user/defaults/main.yml
+++ b/service_user/defaults/main.yml
@@ -5,3 +5,5 @@ service_user_group: "{{ service_user_name }}"
 
 # create user's home directory if it does not exist
 service_user_create_home: true
+
+service_user_home_permissions: 0755

--- a/service_user/tasks/main.yml
+++ b/service_user/tasks/main.yml
@@ -19,6 +19,6 @@
     state: directory
     owner: "{{ service_user_name }}"
     group: "{{ service_user_group }}"
-    mode: 0755
+    mode: "{{ service_user_home_permissions }}"
   when: service_user_create_home
 

--- a/service_user/tasks/main.yml
+++ b/service_user/tasks/main.yml
@@ -10,8 +10,8 @@
     name: "{{ service_user_name }}"
     group: "{{ service_user_group }}"
     shell: /sbin/nologin
-    home: "{{ service_user_home }}"
-    createhome: yes
+    home: "{{ service_user_home | default(omit) }}"
+    createhome: "{{ service_user_create_home }}"
 
 - name: Ensure user home directory exists with proper permissions
   file:
@@ -20,4 +20,5 @@
     owner: "{{ service_user_name }}"
     group: "{{ service_user_group }}"
     mode: 0755
+  when: service_user_create_home
 


### PR DESCRIPTION
Added 2 new properties to the service_user module:

- service_user_create_home - to allow not creating the user's home directory (defaults to true for backward compatibility)
- service_user_home_permissions - defaults to 755 for backward compatibility

Also made the service_user_home property optional, since it is optional in the Ansible user module. 