### PR TITLE
Update InfluxDB and Grafana for CentOS 7 (systemd)

### DIFF
--- a/grafana/tasks/config.yml
+++ b/grafana/tasks/config.yml
@@ -1,12 +1,21 @@
 ---
-- name: copy startup scripts
-  template: src="{{ item.src }}" dest="{{ item.dest }}" owner="root" group="root" mode='0755'
-  with_items:
-    - { src: 'grafana.sh.j2', dest: "/etc/init.d/grafana" }
+- name: Copy Granafa initd script
+  template:
+    src: grafana.sh.j2
+    dest: /etc/init.d/grafana
+    owner: root
+    group: root
+    mode: '0755'
+  when: ansible_distribution == "Amazon" or (ansible_distribution == "CentOS" and ansible_distribution_major_version < "7")
+  notify:
+    - restart grafana
 
-- name: copy grafana configs
-  template: src="{{ item.src }}" dest="{{ item.dest }}" owner="{{ grafana_user }}" group="{{ grafana_user }}" mode='0640'
-  with_items:
-    - { src: 'grafana.ini.j2', dest: "{{grafana_conf_dir}}/grafana.ini" }
+- name: Copy Grafana config
+  template:
+    src: grafana.ini.j2
+    dest: "{{ grafana_conf_dir }}/grafana.ini"
+    owner: "{{ grafana_user }}"
+    group: "{{ grafana_user }}"
+    mode: '0640'
   notify:
     - restart grafana

--- a/grafana/tasks/config.yml
+++ b/grafana/tasks/config.yml
@@ -1,5 +1,5 @@
 ---
-- name: Copy Granafa initd script
+- name: Copy Grafana initd script
   template:
     src: grafana.sh.j2
     dest: /etc/init.d/grafana

--- a/grafana/tasks/install.yml
+++ b/grafana/tasks/install.yml
@@ -6,7 +6,7 @@
     dest: "{{ grafana_dest }}"
     mode: 0755
 
-- name: install grafana rpm from a local file
+- name: Install Grafana rpm from local file
   yum:
     name: "{{ grafana_dest }}/{{ grafana_filename }}"
     state: present

--- a/influxdb/tasks/config.yml
+++ b/influxdb/tasks/config.yml
@@ -11,14 +11,23 @@
     - "{{ influxdb_lib_dir }}"
     - "{{ influxdb_data_dir }}"
 
-- name: copy startup scripts
-  template: src="{{ item.src }}" dest="{{ item.dest }}" owner="root" group="root" mode='0755'
-  with_items:
-    - { src: 'influxdb.sh.j2', dest: "/etc/init.d/influxdb" }
+- name: Copy InfluxDB initd script
+  template:
+    src: influxdb.sh.j2
+    dest: /etc/init.d/influxdb
+    owner: root
+    group: root
+    mode: '0755'
+  when: ansible_distribution == "Amazon" or (ansible_distribution == "CentOS" and ansible_distribution_major_version < "7")
+  notify:
+    - restart influxdb
 
-- name: copy influxdb configs
-  template: src="{{ item.src }}" dest="{{ item.dest }}" owner="{{ influxdb_user }}" group="{{ influxdb_user }}" mode='0644'
-  with_items:
-    - { src: 'influxdb.conf.j2', dest: "{{influxdb_conf_dir}}/influxdb.conf" }
+- name: Copy InfluxDB config
+  template:
+    src: influxdb.conf.j2
+    dest: "{{ influxdb_conf_dir }}/influxdb.conf"
+    owner: "{{ influxdb_user }}"
+    group: "{{ influxdb_user }}"
+    mode: '0644'
   notify:
     - restart influxdb

--- a/influxdb/tasks/install.yml
+++ b/influxdb/tasks/install.yml
@@ -6,7 +6,7 @@
     dest: "{{ influxdb_dest }}"
     mode: 0755
 
-- name: install influx rpm from a local file
+- name: Install InfluxDB rpm from local file
   yum:
     name: "{{ influxdb_dest }}/{{ influxdb_filename }}"
     state: present


### PR DESCRIPTION
Updated the InfluxDB and Grafana roles to allow them to work on CentOS 7.

Both RPM's include both an init.d script and a systemd service. So I simply placed a when clause on the init.d blocks in the roles so that they would not run on CentOS, and instead rely on the RPM doing its job in installing the systemd service. I suspect that the init.d blocks in the roles could be removed, but I do not have a suitable environment to verify. These changes should preserve backward compatibility on CentOS 6 and similar variants.