### PR TITLE
EACCESS -> EACCES

### DIFF
--- a/nist_compliance/templates/rulesd_compliance.rules.j2
+++ b/nist_compliance/templates/rulesd_compliance.rules.j2
@@ -64,8 +64,8 @@
 -a always,exit -F arch=b32 -S open -F exit=-EPERM -k SYS_open
 
 ## Unsuccessful close
--a always,exit -F arch=b64 -S close -F exit=-EACCESS -k SYS_close
--a always,exit -F arch=b32 -S close -F exit=-EACCESS -k SYS_close
+-a always,exit -F arch=b64 -S close -F exit=-EACCES -k SYS_close
+-a always,exit -F arch=b32 -S close -F exit=-EACCES -k SYS_close
 
 ## Unsuccessful modifications
 -a always,exit -F arch=b64 -S rename -S truncate -S ftruncate -F exit=-EACCES -k SYS_mods


### PR DESCRIPTION
I know almost nothing about auditd and these rules, but this appears to be a typo in the template. I cannot find anything online about EACCESS, but we seem to be using EACCES throughout this file. We were trying to send these compliance.rules to Elastic's Auditbeat and getting an error about not recognizing "-EACCESS". I changed it to -EACCES and that cleared the error up.