### PR TITLE
Allow Grafana Config to use variables

### DIFF
--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -17,5 +17,3 @@ grafana_external_image_storage_s3_bucket_url: ''
 
 grafana_smtp_enabled: false
 grafana_smtp_display_name: "Grafana"
-
-grafana_server_domain: localhost

--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -17,3 +17,4 @@ grafana_external_image_storage_s3_bucket_url: ''
 
 grafana_smtp_enabled: false
 grafana_smtp_display_name: "Grafana"
+grafana_smtp_host: "localhost:25"

--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -15,3 +15,7 @@ grafana_log_level: 'info'
 grafana_external_image_storage_provider: ''
 grafana_external_image_storage_s3_bucket_url: ''
 
+grafana_smtp_enabled: false
+grafana_smtp_display_name: "Grafana"
+
+grafana_server_domain: localhost

--- a/grafana/templates/grafana.ini.j2
+++ b/grafana/templates/grafana.ini.j2
@@ -286,7 +286,7 @@ editors_can_admin = true
 
 #################################### SMTP / Emailing ##########################
 [smtp]
-;enabled = false
+enabled = {{ grafana_smtp_enabled|lower }}
 ;host = localhost:25
 ;user =
 # If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
@@ -295,7 +295,7 @@ editors_can_admin = true
 ;key_file =
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
-;from_name = Grafana
+from_name = {{ grafana_smtp_display_name }}
 
 [emails]
 ;welcome_email_on_sign_up = false

--- a/grafana/templates/grafana.ini.j2
+++ b/grafana/templates/grafana.ini.j2
@@ -287,7 +287,10 @@ editors_can_admin = true
 #################################### SMTP / Emailing ##########################
 [smtp]
 enabled = {{ grafana_smtp_enabled|lower }}
-;host = localhost:25
+{% if grafana_smtp_enabled %}
+host = {{ grafana_smtp_host }}
+{% endif %}
+
 ;user =
 # If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
 ;password =


### PR DESCRIPTION
Creating a few variables that will be used to alter a few SMTP settings. 

All of the defaults have been maintained through the main.yml file, but they can be changed to specific values that are mapped to the grafana.ini.j2 template.