### PR TITLE
Update compliance and accounts to support users with passwords

### DIFF
--- a/accounts/tasks/create.yml
+++ b/accounts/tasks/create.yml
@@ -5,13 +5,32 @@
   group: name="{{ item.username }}"
   with_items: "{{ accounts_create_users }}"
 
+# Any user in the allowpass group is allowed to login with a password.
+# If you have a user that requires a password, add "allow_password: yes"
+# to their accounts entry in group_vars/.../accounts.
+- name: create allowpass group for users that can use passwords
+  group:
+    name: allowpass
+    state: present
+
+- name: allow password auth in sshd_config for pword group
+  blockinfile:
+    path: /etc/ssh/sshd_config
+    block: |
+      Match Group allowpass
+      PasswordAuthentication yes
+      Match User *
+  notify:
+    - restart sshd
+
 - name: create users
   user: name="{{ item.username }}"
         uid="{{ item.uid | default(omit) }}"
         group="{{ item.username }}"
-        groups="{{ (item.groups | default([])) | join(',') }}"
+        groups="{{ ( (["allowpass"] if (item.allow_password | default(False)) else [] ) + (item.groups | default([])) ) | join(',') }}"
         shell="{{ item.shell if item.shell is defined else accounts_shell }}"
         password="{{ item.password if item.password is defined else '!' }}"
+        update_password="on_create"
         comment="{{ item.name | default(omit) }}"
         home="{{item.home if item.home is defined else accounts_home_root+item.username}}"
         createhome="{{ accounts_createhome }}"

--- a/nist_compliance/tasks/main.yml
+++ b/nist_compliance/tasks/main.yml
@@ -89,6 +89,11 @@
   template: src="password-auth-ac.j2" dest="/etc/pam.d/password-auth-ac" owner='root' group='root' mode='0644'
   tags: [compliance, pamd]
 
+- name: create allowpass group for users that can use passwords
+  group:
+    name: allowpass
+    state: present
+
 - name: Check for /etc/bashrc
   stat: path=/etc/bashrc
   register: bashrc_stat

--- a/nist_compliance/templates/sshd_config.j2
+++ b/nist_compliance/templates/sshd_config.j2
@@ -143,3 +143,9 @@ Subsystem sftp	/usr/libexec/openssh/sftp-server
 
 UseDNS no
 AllowUsers {% if privileged_user is defined %}{{ privileged_user }} {% endif %}{{ accounts_create_users|map(attribute='username')|sort|join(' ') }}
+
+# BEGIN ANSIBLE MANAGED BLOCK
+Match Group allowpass
+PasswordAuthentication yes
+Match User *
+# END ANSIBLE MANAGED BLOCK


### PR DESCRIPTION
We now have projects that require us to use password authentication for linux instead of RSA keys. These changes are backwards compatible.

Updates:
- Updated compliance role to create an 'allowpass' group
- Updated compliance role to ensure sshd_config allows password auth for anyone in the allowpass group
- Updated accounts to support an "allow_password" flag on users
- Updated accounts to add users to 'allowpass' group if their allow_password flag is true

To verify:

1. Run compliance.yml and accounts.yml on your project and verify that the allowpass group is created, but none of your users are added to it.
2. Set the 'allow_password' flag to yes for one of your users, run accounts, and verify that the user is added to the allowpass group.
3. Remove the 'allow_password' flag from that user, re-run accounts, and verify that the user is removed from the allowpass group.
