### PR TITLE
Devops role for mitogen install

### DIFF
--- a/mitogen/README.md
+++ b/mitogen/README.md
@@ -11,7 +11,7 @@ Target host must be able to reach yum repositories, pip repository, and be a sup
 Role Variables
 --------------
 
-    set_umask: umask to set mitogen installatio path (Default: "0022"). Default allows all users to use mitogen.
+    set_umask: umask to set mitogen installation path (Default: "0022"). Default allows all users to use mitogen.
 
 Example Playbook
 ----------------

--- a/mitogen/README.md
+++ b/mitogen/README.md
@@ -1,0 +1,29 @@
+mitogen
+===
+
+An Ansible role to install mitogen on CentOS 7 and Amazon Linux 2
+
+Requirements
+------------
+
+Target host must be able to reach yum repositories, pip repository, and be a supported OS
+
+Role Variables
+--------------
+
+    set_umask: umask to set mitogen installatio path (Default: "0022"). Default allows all users to use mitogen.
+
+Example Playbook
+----------------
+
+    - name: Example Playbook
+      hosts: servers
+      roles:
+        - name: install mitogen via pip
+          role: mitogen
+
+License
+-------
+
+MIT
+

--- a/mitogen/defaults/main.yml
+++ b/mitogen/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for mitogen
+
+set_umask: "0022"

--- a/mitogen/meta/main.yml
+++ b/mitogen/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - name: install pip
+    role: pip
+    tags: [ pip, dependency ]

--- a/mitogen/tasks/main.yml
+++ b/mitogen/tasks/main.yml
@@ -7,13 +7,6 @@
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
   tags: [ mitogen, epel ]
 
-- name: ensure pip is installed
-  yum:
-    name:
-      - python-pip
-    state: present
-  tags: [ mitogen, yum ]
-
 - name: pip install setuptools
   pip:
     name: setuptools

--- a/mitogen/tasks/main.yml
+++ b/mitogen/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- name: add EPEL repo on CentOS
+  yum:
+    name: epel-release
+    state: present
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
+  tags: [ mitogen, epel ]
+
+- name: ensure pip is installed
+  yum:
+    name:
+      - python-pip
+    state: present
+  tags: [ mitogen, yum ]
+
+- name: pip install setuptools
+  pip:
+    name: setuptools
+    state: present
+  tags: [ mitogen, pip ]
+
+- name: pip install mitogen
+  pip:
+    name: mitogen
+    umask: '{{ set_umask }}'
+    state: present
+  tags: [ mitogen, install ]


### PR DESCRIPTION
Created role to install mitogen on CentOS7 and AmazonLinux2 instances. The role installs mitogen through pip with a umask of 0022 which allows all users to use mitogen.