### PR TITLE
Grafana: Adding in interpolated vars for auth proxy section

### DIFF
--- a/grafana/defaults/main.yml
+++ b/grafana/defaults/main.yml
@@ -18,3 +18,10 @@ grafana_external_image_storage_s3_bucket_url: ''
 grafana_smtp_enabled: false
 grafana_smtp_display_name: "Grafana"
 grafana_smtp_host: "localhost:25"
+
+grafana_auth_proxy_enabled: false
+grafana_auth_proxy_header_name: "X-WEBAUTH-USER"
+grafana_auth_proxy_header_property: "username"
+grafana_auth_proxy_auto_sign_up: true
+grafana_signout_redirect_enabled: false
+grafana_signout_redirect_url: ""

--- a/grafana/templates/grafana.ini.j2
+++ b/grafana/templates/grafana.ini.j2
@@ -277,7 +277,6 @@ header_name = {{ grafana_auth_proxy_header_name }}
 header_property = {{ grafana_auth_proxy_header_property }}
 auto_sign_up = {{ grafana_auth_proxy_auto_sign_up|lower }}
 {% endif %}
-
 ;ldap_sync_ttl = 60
 ;whitelist = 192.168.1.1, 192.168.2.1
 

--- a/grafana/templates/grafana.ini.j2
+++ b/grafana/templates/grafana.ini.j2
@@ -275,7 +275,7 @@ enabled = {{ grafana_auth_proxy_enabled|lower }}
 {% if grafana_auth_proxy_enabled %}
 header_name = {{ grafana_auth_proxy_header_name }}
 header_property = {{ grafana_auth_proxy_header_property }}
-auto_sign_up = {{ grafana_auth_proxy_auto_sign_up }}
+auto_sign_up = {{ grafana_auth_proxy_auto_sign_up|lower }}
 {% endif %}
 
 ;ldap_sync_ttl = 60

--- a/grafana/templates/grafana.ini.j2
+++ b/grafana/templates/grafana.ini.j2
@@ -203,6 +203,10 @@ editors_can_admin = true
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
 
+{% if grafana_signout_redirect_enabled %}
+signout_redirect_url = {{ grafana_signout_redirect_url }}
+{% endif %}
+
 # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
 ;disable_signout_menu = false
 
@@ -267,10 +271,13 @@ editors_can_admin = true
 
 #################################### Auth Proxy ##########################
 [auth.proxy]
-;enabled = false
-;header_name = X-WEBAUTH-USER
-;header_property = username
-;auto_sign_up = true
+enabled = {{ grafana_auth_proxy_enabled|lower }}
+{% if grafana_auth_proxy_enabled %}
+header_name = {{ grafana_auth_proxy_header_name }}
+header_property = {{ grafana_auth_proxy_header_property }}
+auto_sign_up = {{ grafana_auth_proxy_auto_sign_up }}
+{% endif %}
+
 ;ldap_sync_ttl = 60
 ;whitelist = 192.168.1.1, 192.168.2.1
 


### PR DESCRIPTION
Ostrich is utilizing auth_proxy on our customer instances and would like the ability to set our own variables for the auth-proxy-related variables.

If you are using Grafana, the changes made in this PR should not result in any changes. Everything should be setting to whatever the default was in the .ini file so that teams can set their own variables within their own Ansible environment.