### PR TITLE
Adding new clamav role

### DIFF
--- a/clamav/README.md
+++ b/clamav/README.md
@@ -1,0 +1,75 @@
+clamav
+========
+
+An Ansible role for installing clamav on a Linux system.
+
+Requirements
+------------
+
+Assumes a Unix/Linux OS, and has only been tested on the Amazon Linux 2 OS.  Integration with 
+Cloudwatch for virus event notifications is incorporated through the use of two shell scripts 
+that require the aws cli tools to be in place on the system.  These scripts also assume the associated
+Cloudwatch alarm, SNS topics, etc. are already in place (via terraform or other methods).
+
+Role Variables
+--------------
+
+Other variables that can be passed to this role and a brief description about
+them are as follows. These variables should be configured as group_vars if possible.
+
+    # Name of the clamav daemon/service
+    clamav_daemon: 'clamd@scan'
+    # Default state of the clamav daemon/service after apply
+    clamav_daemon_state: started
+    # Enable/Disable the clamav daemon/service after apply
+    clamav_daemon_enabled: true
+
+    # Name of the freshclam virus def update daemon/service 
+    clamav_freshclam_daemon: 'clamd-freshclam'
+    # Default state of the freshclam daemon/service after apply
+    clamav_freshclam_daemon_state: started
+    # Enable/Disable the freshclam daemon/service after apply
+    clamav_freshclam_daemon_enabled: true
+
+    # Name of the ClamAV OnAccess Scanner daemon/service
+    clamav_clamonacc_daemon: 'clamav-clamonacc'
+    # Default state of the ClamAV OnAccess Scanner daemon/service after apply
+    clamav_clamonacc_daemon_state: started
+    # Enable/Disable the freshclam daemon/service after apply
+    clamav_clamonacc_daemon_enabled: true
+
+    # Local socket path for the clamav daemon to bind to
+    clamav_daemon_localsocket: /var/run/clamd.scan/clamd.sock
+    # Location for the clamav configuration files
+    clamav_daemon_config_path: /etc/clamd.d/scan.conf
+    # List of packages to be installed as part of clamav
+    clamav_packages:
+      - amazon-linux-extras
+      - clamav
+      - clamav-update
+      - clamd
+
+    # Ownership permissions for cloudwatch alarm bash script  
+    clamav_cloudwatch_script_group: root
+    clamav_cloudwatch_script_owner: root
+    # Name of the Cloudwatch virus event alarm in AWS
+    cloudwatch_clamav_alarm_name: cloudwatch-clamav-virus-found
+
+    # The region associated with the AWS account (used for Cloudwatch)
+    aws_region: us-east-1
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      become: yes
+      become_method: sudo
+      roles:
+        - name: Install ClamAV
+          role: clamav
+
+License
+-------
+
+MIT
+

--- a/clamav/defaults/main.yml
+++ b/clamav/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+clamav_daemon: 'clamd@scan'
+clamav_daemon_state: started
+clamav_daemon_enabled: true
+
+clamav_freshclam_daemon: 'clamd-freshclam'
+clamav_freshclam_daemon_state: started
+clamav_freshclam_daemon_enabled: true
+
+clamav_clamonacc_daemon: 'clamav-clamonacc'
+clamav_clamonacc_daemon_state: started
+clamav_clamonacc_daemon_enabled: true
+
+clamav_daemon_localsocket: /var/run/clamd.scan/clamd.sock
+clamav_daemon_config_path: /etc/clamd.d/scan.conf
+clamav_packages:
+  - amazon-linux-extras
+  - clamav
+  - clamav-update
+  - clamd
+
+clamav_cloudwatch_script_group: root
+clamav_cloudwatch_script_owner: root
+cloudwatch_clamav_alarm_name: cloudwatch-clamav-virus-found
+
+aws_region: us-east-1

--- a/clamav/defaults/main.yml
+++ b/clamav/defaults/main.yml
@@ -22,5 +22,3 @@ clamav_packages:
 clamav_cloudwatch_script_group: root
 clamav_cloudwatch_script_owner: root
 cloudwatch_clamav_alarm_name: cloudwatch-clamav-virus-found
-
-aws_region: us-east-1

--- a/clamav/handlers/main.yml
+++ b/clamav/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: restart clamav daemon
+  service:
+    name: "{{ clamav_daemon }}"
+    state: restarted
+  when: clamav_daemon_state != 'stopped'
+
+- name: restart crond
+  service: 
+    name: crond 
+    state: restarted

--- a/clamav/tasks/main.yml
+++ b/clamav/tasks/main.yml
@@ -1,0 +1,122 @@
+---
+- name: Install epel from AL2 extras
+  command: amazon-linux-extras install epel -y
+  tags: [ clamav ]
+
+- name: Ensure ClamAV packages are installed.
+  package: 
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ clamav_packages }}"
+  register: clamav_packages_install
+  tags: [ clamav ]
+
+- name: Ensure clamav log directory
+  file: 
+    path: /var/log/clamav 
+    state: directory 
+    owner: clamscan
+    group: clamscan
+    mode: 0700
+  tags: [ clamav ]
+
+- name: Run freshclam after ClamAV packages change.
+  command: freshclam
+  when: clamav_packages_install.changed
+  register: freshclam_result
+  notify: restart clamav daemon
+  failed_when:
+    - freshclam_result is failed
+    - freshclam_result.stderr.find('locked by another process') != -1
+  tags: [ clamav, freshclam ]
+
+- name: Ensure Freshclam service is available.
+  template:
+    src: clamd-freshclam.service.j2
+    dest: /lib/systemd/system/clamd-freshclam.service
+    mode: 0644
+  register: freshclam_service_template
+  tags: [ clamav, freshclam ]
+
+- name: Reload systemd after adding freshclam service.
+  systemd:
+    state: stopped
+    daemon_reload: true
+    name: "{{ clamav_freshclam_daemon }}"
+  when: freshclam_service_template.changed
+  tags: [ clamav, freshclam ]
+
+- name: Ensure clamav config file is in place
+  template:
+    src: scan.conf.j2
+    dest: /etc/clamd.d/scan.conf
+    owner: root
+    group: root
+    mode: 0644
+  tags: [ clamav ]
+
+- name: Ensure ClamAV OnAccess service is available.
+  template:
+    src: clamav-clamonacc.service.j2
+    dest: /lib/systemd/system/clamav-clamonacc.service
+    mode: 0644
+  register: clamonacc_service_template
+  tags: [ clamav, clamonacc ]
+
+- name: Reload systemd after adding clamonacc service.
+  systemd:
+    state: stopped
+    daemon_reload: true
+    name: "{{ clamav_clamonacc_daemon }}"
+  when: clamonacc_service_template.changed
+  tags: [ clamav, clamonacc ]
+
+- name: Ensure ClamAV daemon is running (if configured).
+  service:
+    name: "{{ clamav_daemon }}"
+    state: "{{ clamav_daemon_state }}"
+    enabled: "{{ clamav_daemon_enabled }}"
+  tags: [ clamav ]
+
+- name: Ensure ClamAV OnAccess daemon is running (if configured).
+  service:
+    name: "{{ clamav_clamonacc_daemon }}"
+    state: "{{ clamav_clamonacc_daemon_state }}"
+    enabled: "{{ clamav_clamonacc_daemon_enabled }}"
+  tags: [ clamav, clamonacc ]
+
+- name: Ensure ClamAV freshclam daemon is running (if configured).
+  service:
+    name: "{{ clamav_freshclam_daemon }}"
+    state: "{{ clamav_freshclam_daemon_state }}"
+    enabled: "{{ clamav_freshclam_daemon_enabled }}"
+  tags: [ clamav, freshclam ]
+
+- name: Enable Weekly ClamAV Scan Cron
+  template:
+    src: clamscan_weekly.sh.j2
+    dest: /etc/cron.weekly/clamscan_weekly
+    owner: root
+    group: root
+    mode: 0700
+  tags: [ clamav ]
+  notify:
+    - restart crond
+
+- name: Ensure CloudWatch event clear script
+  template:
+    src: cloudwatch_virusalarm_clear.sh.j2
+    dest: /etc/clamd.d/cloudwatch_virusalarm_clear.sh
+    owner: "{{ clamav_cloudwatch_script_owner }}"
+    group: "{{ clamav_cloudwatch_script_group }}"
+    mode: 0700
+  tags: [ clamav ]
+
+- name: Ensure CloudWatch event trigger script
+  template:
+    src: cloudwatch_virusalarm_trigger.sh.j2
+    dest: /etc/clamd.d/cloudwatch_virusalarm_trigger.sh
+    owner: "{{ clamav_cloudwatch_script_owner }}"
+    group: "{{ clamav_cloudwatch_script_group }}"
+    mode: 0700
+  tags: [ clamav ]

--- a/clamav/templates/clamav-clamonacc.service.j2
+++ b/clamav/templates/clamav-clamonacc.service.j2
@@ -1,0 +1,15 @@
+# clamonacc systemd service file primarily the work of ChadDevOps & Aaron Brighton
+# See: https://medium.com/@aaronbrighton/installation-configuration-of-clamav-antivirus-on-ubuntu-18-04-a6416bab3b41#a340
+
+[Unit]
+Description=ClamAV On-Access Scanner
+Documentation=man:clamonacc(8) man:clamd.conf(5) https://www.clamav.net/documents
+After=clamd@scan.service syslog.target network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/sbin/clamonacc -F --config-file=/etc/clamd.d/scan.conf --log=/var/log/clamav/clamonacc.log --remove
+
+[Install]
+WantedBy=multi-user.target

--- a/clamav/templates/clamd-freshclam.service.j2
+++ b/clamav/templates/clamd-freshclam.service.j2
@@ -1,0 +1,13 @@
+# Run freshclam as a daemon.
+[Unit]
+Description = ClamAV Freshclam service.
+After = network.target
+
+[Service]
+Type = forking
+ExecStart = /usr/bin/freshclam --daemon --checks 2 --log=/var/log/clamav/freshclam.log
+Restart = on-failure
+PrivateTmp = true
+
+[Install]
+WantedBy=multi-user.target

--- a/clamav/templates/clamscan_weekly.sh.j2
+++ b/clamav/templates/clamscan_weekly.sh.j2
@@ -1,0 +1,32 @@
+#!/bin/bash
+LOGFILE="/var/log/clamav/clamscan-weekly-$(date +'%Y-%m-%d').log";
+ALERT_MSG="Virus Detected - Notification has been sent to Cloudwatch";
+DIRTOSCAN="/";
+
+#Stop the clamav daemons
+systemctl stop clamav-clamonacc
+systemctl stop clamd@scan
+
+for DIR in ${DIRTOSCAN}; do
+ DIRSIZE=$(du -sh "$DIR" 2>/dev/null | cut -f1);
+
+ echo "Starting a weekly scan of "$DIR" directory. 
+ Amount of data to be scanned is "$DIRSIZE"." > $LOGFILE;
+
+ clamscan -ri --remove=yes "$DIR" >> "$LOGFILE";
+
+ # get the value of "Infected lines"
+ MALWARE=$(tail "$LOGFILE"|grep Infected|cut -d" " -f3);
+
+ # if the value is not equal to zero, execute command to trigger alert in Cloudwatch
+ if [ $MALWARE -ne 0 ];then
+ echo $ALERT_MSG >> $LOGFILE
+ bash /etc/clam.d/cloudwatch_virusalarm_trigger.sh
+ fi
+done
+
+#Start the clamav daemon
+systemctl start clamd@scan
+systemctl start clamav-clamonacc
+
+exit 0

--- a/clamav/templates/cloudwatch_virusalarm_clear.sh.j2
+++ b/clamav/templates/cloudwatch_virusalarm_clear.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Sets the state of the clamav virus alarm in Cloudwatch to OK
+aws cloudwatch set-alarm-state --alarm-name {{ cloudwatch_clamav_alarm_name }} \
+--state-reason "System Administrator has investigated and determined the issue to be resolved" \
+--state-value OK --region {{ aws_region }}

--- a/clamav/templates/cloudwatch_virusalarm_trigger.sh.j2
+++ b/clamav/templates/cloudwatch_virusalarm_trigger.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Sets the state of the clamav virus alarm in Cloudwatch to ALARM
+aws cloudwatch set-alarm-state --alarm-name {{ cloudwatch_clamav_alarm_name }} \
+--state-reason "Virus event detected on $HOSTNAME.  Please investigate and execute /etc/clamd.d/cloudwatch_virusalarm_clear.sh once the issue is resolved." \
+--state-value ALARM --region {{ aws_region }}

--- a/clamav/templates/scan.conf.j2
+++ b/clamav/templates/scan.conf.j2
@@ -1,0 +1,792 @@
+##
+## Example config file for the Clam AV daemon
+## Please read the clamd.conf(5) manual before editing this file.
+##
+
+
+# Comment or remove the line below.
+
+# Uncomment this option to enable logging.
+# LogFile must be writable for the user running daemon.
+# A full path is required.
+# Default: disabled
+LogFile /var/log/clamav/clamd.log
+
+# By default the log file is locked for writing - the lock protects against
+# running clamd multiple times (if want to run another clamd, please
+# copy the configuration file, change the LogFile variable, and run
+# the daemon with --config-file option).
+# This option disables log file locking.
+# Default: no
+#LogFileUnlock yes
+
+# Maximum size of the log file.
+# Value of 0 disables the limit.
+# You may use 'M' or 'm' for megabytes (1M = 1m = 1048576 bytes)
+# and 'K' or 'k' for kilobytes (1K = 1k = 1024 bytes). To specify the size
+# in bytes just don't use modifiers. If LogFileMaxSize is enabled, log
+# rotation (the LogRotate option) will always be enabled.
+# Default: 1M
+#LogFileMaxSize 2M
+
+# Log time with each message.
+# Default: no
+LogTime yes
+
+# Also log clean files. Useful in debugging but drastically increases the
+# log size.
+# Default: no
+#LogClean yes
+
+# Use system logger (can work together with LogFile).
+# Default: no
+#LogSyslog yes
+
+# Specify the type of syslog messages - please refer to 'man syslog'
+# for facility names.
+# Default: LOG_LOCAL6
+#LogFacility LOG_MAIL
+
+# Enable verbose logging.
+# Default: no
+#LogVerbose yes
+
+# Enable log rotation. Always enabled when LogFileMaxSize is enabled.
+# Default: no
+LogRotate yes
+
+# Enable Prelude output.
+# Default: no
+#PreludeEnable yes
+#
+# Set the name of the analyzer used by prelude-admin.
+# Default: ClamAV
+#PreludeAnalyzerName ClamAV
+
+# Log additional information about the infected file, such as its
+# size and hash, together with the virus name.
+ExtendedDetectionInfo yes
+
+# This option allows you to save a process identifier of the listening
+# daemon (main thread).
+# This file will be owned by root, as long as clamd was started by root.
+# It is recommended that the directory where this file is stored is
+# also owned by root to keep other users from tampering with it.
+# Default: disabled
+#PidFile /run/clamd.scan/clamd.pid
+
+# Optional path to the global temporary directory.
+# Default: system specific (usually /tmp or /var/tmp).
+#TemporaryDirectory /var/tmp
+
+# Path to the database directory.
+# Default: hardcoded (depends on installation options)
+#DatabaseDirectory /var/lib/clamav
+
+# Only load the official signatures published by the ClamAV project.
+# Default: no
+#OfficialDatabaseOnly no
+
+# The daemon can work in local mode, network mode or both.
+# Due to security reasons we recommend the local mode.
+
+# Path to a local socket file the daemon will listen on.
+# Default: disabled (must be specified by a user)
+#LocalSocket /var/run/clamd.scan/clamd.sock
+
+# Sets the group ownership on the unix socket.
+# Default: disabled (the primary group of the user running clamd)
+#LocalSocketGroup virusgroup
+
+# Sets the permissions on the unix socket to the specified mode.
+# Default: disabled (socket is world accessible)
+#LocalSocketMode 660
+
+# Remove stale socket after unclean shutdown.
+# Default: yes
+#FixStaleSocket yes
+
+# TCP port address.
+# Default: no
+TCPSocket 3310
+
+# TCP address.
+# By default we bind to INADDR_ANY, probably not wise.
+# Enable the following to provide some degree of protection
+# from the outside world. This option can be specified multiple
+# times if you want to listen on multiple IPs. IPv6 is now supported.
+# Default: no
+TCPAddr 127.0.0.1
+
+# Maximum length the queue of pending connections may grow to.
+# Default: 200
+#MaxConnectionQueueLength 30
+
+# Clamd uses FTP-like protocol to receive data from remote clients.
+# If you are using clamav-milter to balance load between remote clamd daemons
+# on firewall servers you may need to tune the options below.
+
+# Close the connection when the data size limit is exceeded.
+# The value should match your MTA's limit for a maximum attachment size.
+# Default: 25M
+#StreamMaxLength 10M
+
+# Limit port range.
+# Default: 1024
+#StreamMinPort 30000
+# Default: 2048
+#StreamMaxPort 32000
+
+# Maximum number of threads running at the same time.
+# Default: 10
+#MaxThreads 20
+
+# Waiting for data from a client socket will timeout after this time (seconds).
+# Default: 120
+#ReadTimeout 300
+
+# This option specifies the time (in seconds) after which clamd should
+# timeout if a client doesn't provide any initial command after connecting.
+# Default: 30
+#CommandReadTimeout 30
+
+# This option specifies how long to wait (in milliseconds) if the send buffer
+# is full.
+# Keep this value low to prevent clamd hanging.
+#
+# Default: 500
+#SendBufTimeout 200
+
+# Maximum number of queued items (including those being processed by
+# MaxThreads threads).
+# It is recommended to have this value at least twice MaxThreads if possible.
+# WARNING: you shouldn't increase this too much to avoid running out  of file
+# descriptors, the following condition should hold:
+# MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual
+# max is 1024).
+#
+# Default: 100
+#MaxQueue 200
+
+# Waiting for a new job will timeout after this time (seconds).
+# Default: 30
+#IdleTimeout 60
+
+# Don't scan files and directories matching regex
+# This directive can be used multiple times
+# Default: scan all
+#ExcludePath ^/proc/
+#ExcludePath ^/sys/
+
+# Maximum depth directories are scanned at.
+# Default: 15
+#MaxDirectoryRecursion 20
+
+# Follow directory symlinks.
+# Default: no
+#FollowDirectorySymlinks yes
+
+# Follow regular file symlinks.
+# Default: no
+#FollowFileSymlinks yes
+
+# Scan files and directories on other filesystems.
+# Default: yes
+#CrossFilesystems yes
+
+# Perform a database check.
+# Default: 600 (10 min)
+#SelfCheck 600
+
+# Enable non-blocking (multi-threaded/concurrent) database reloads.
+# This feature will temporarily load a second scanning engine while scanning
+# continues using the first engine. Once loaded, the new engine takes over.
+# The old engine is removed as soon as all scans using the old engine have
+# completed.
+# This feature requires more RAM, so this option is provided in case users are
+# willing to block scans during reload in exchange for lower RAM requirements.
+# Default: yes
+#ConcurrentDatabaseReload no
+
+# Execute a command when virus is found. In the command string %v will
+# be replaced with the virus name.
+# Default: no
+VirusEvent /etc/clam.d/cloudwatch_virusalarm_trigger.sh
+
+# Run as another user (clamd must be started by root for this option to work)
+# Default: don't drop privileges
+User clamscan
+
+# Stop daemon when libclamav reports out of memory condition.
+#ExitOnOOM yes
+
+# Don't fork into background.
+# Default: no
+#Foreground yes
+
+# Enable debug messages in libclamav.
+# Default: no
+#Debug yes
+
+# Do not remove temporary files (for debug purposes).
+# Default: no
+#LeaveTemporaryFiles yes
+
+# Permit use of the ALLMATCHSCAN command. If set to no, clamd will reject
+# any ALLMATCHSCAN command as invalid.
+# Default: yes
+#AllowAllMatchScan no
+
+# Detect Possibly Unwanted Applications.
+# Default: no
+#DetectPUA yes
+
+# Exclude a specific PUA category. This directive can be used multiple times.
+# See https://github.com/vrtadmin/clamav-faq/blob/master/faq/faq-pua.md for
+# the complete list of PUA categories.
+# Default: Load all categories (if DetectPUA is activated)
+#ExcludePUA NetTool
+#ExcludePUA PWTool
+
+# Only include a specific PUA category. This directive can be used multiple
+# times.
+# Default: Load all categories (if DetectPUA is activated)
+#IncludePUA Spy
+#IncludePUA Scanner
+#IncludePUA RAT
+
+# This option causes memory or nested map scans to dump the content to disk.
+# If you turn on this option, more data is written to disk and is available
+# when the LeaveTemporaryFiles option is enabled.
+#ForceToDisk yes
+
+# This option allows you to disable the caching feature of the engine. By
+# default, the engine will store an MD5 in a cache of any files that are
+# not flagged as virus or that hit limits checks. Disabling the cache will
+# have a negative performance impact on large scans.
+# Default: no
+#DisableCache yes
+
+# In some cases (eg. complex malware, exploits in graphic files, and others),
+# ClamAV uses special algorithms to detect abnormal patterns and behaviors that
+# may be malicious.  This option enables alerting on such heuristically
+# detected potential threats.
+# Default: yes
+#HeuristicAlerts yes
+
+# Allow heuristic alerts to take precedence.
+# When enabled, if a heuristic scan (such as phishingScan) detects
+# a possible virus/phish it will stop scan immediately. Recommended, saves CPU
+# scan-time.
+# When disabled, virus/phish detected by heuristic scans will be reported only
+# at the end of a scan. If an archive contains both a heuristically detected
+# virus/phish, and a real malware, the real malware will be reported
+#
+# Keep this disabled if you intend to handle "*.Heuristics.*" viruses
+# differently from "real" malware.
+# If a non-heuristically-detected virus (signature-based) is found first,
+# the scan is interrupted immediately, regardless of this config option.
+#
+# Default: no
+#HeuristicScanPrecedence yes
+
+
+##
+## Heuristic Alerts
+##
+
+# With this option clamav will try to detect broken executables (both PE and
+# ELF) and alert on them with the Broken.Executable heuristic signature.
+# Default: no
+#AlertBrokenExecutables yes
+
+# With this option clamav will try to detect broken media file (JPEG,
+# TIFF, PNG, GIF) and alert on them with a Broken.Media heuristic signature.
+# Default: no
+#AlertBrokenMedia yes
+
+# Alert on encrypted archives _and_ documents with heuristic signature
+# (encrypted .zip, .7zip, .rar, .pdf).
+# Default: no
+#AlertEncrypted yes
+
+# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip,
+# .rar).
+# Default: no
+#AlertEncryptedArchive yes
+
+# Alert on encrypted archives with heuristic signature (encrypted .pdf).
+# Default: no
+#AlertEncryptedDoc yes
+
+# With this option enabled OLE2 files containing VBA macros, which were not
+# detected by signatures will be marked as "Heuristics.OLE2.ContainsMacros".
+# Default: no
+#AlertOLE2Macros yes
+
+# Alert on SSL mismatches in URLs, even if the URL isn't in the database.
+# This can lead to false positives.
+# Default: no
+#AlertPhishingSSLMismatch yes
+
+# Alert on cloaked URLs, even if URL isn't in database.
+# This can lead to false positives.
+# Default: no
+#AlertPhishingCloak yes
+
+# Alert on raw DMG image files containing partition intersections
+# Default: no
+#AlertPartitionIntersection yes
+
+
+##
+## Executable files
+##
+
+# PE stands for Portable Executable - it's an executable file format used
+# in all 32 and 64-bit versions of Windows operating systems. This option
+# allows ClamAV to perform a deeper analysis of executable files and it's also
+# required for decompression of popular executable packers such as UPX, FSG,
+# and Petite. If you turn off this option, the original files will still be
+# scanned, but without additional processing.
+# Default: yes
+#ScanPE yes
+
+# Certain PE files contain an authenticode signature. By default, we check
+# the signature chain in the PE file against a database of trusted and
+# revoked certificates if the file being scanned is marked as a virus.
+# If any certificate in the chain validates against any trusted root, but
+# does not match any revoked certificate, the file is marked as whitelisted.
+# If the file does match a revoked certificate, the file is marked as virus.
+# The following setting completely turns off authenticode verification.
+# Default: no
+#DisableCertCheck yes
+
+# Executable and Linking Format is a standard format for UN*X executables.
+# This option allows you to control the scanning of ELF files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanELF yes
+
+
+##
+## Documents
+##
+
+# This option enables scanning of OLE2 files, such as Microsoft Office
+# documents and .msi files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanOLE2 yes
+
+# This option enables scanning within PDF files.
+# If you turn off this option, the original files will still be scanned, but
+# without decoding and additional processing.
+# Default: yes
+#ScanPDF yes
+
+# This option enables scanning within SWF files.
+# If you turn off this option, the original files will still be scanned, but
+# without decoding and additional processing.
+# Default: yes
+#ScanSWF yes
+
+# This option enables scanning xml-based document files supported by libclamav.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanXMLDOCS yes
+
+# This option enables scanning of HWP3 files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanHWP3 yes
+
+
+##
+## Mail files
+##
+
+# Enable internal e-mail scanner.
+# If you turn off this option, the original files will still be scanned, but
+# without parsing individual messages/attachments.
+# Default: yes
+#ScanMail yes
+
+# Scan RFC1341 messages split over many emails.
+# You will need to periodically clean up $TemporaryDirectory/clamav-partial
+# directory.
+# WARNING: This option may open your system to a DoS attack.
+#	   Never use it on loaded servers.
+# Default: no
+#ScanPartialMessages yes
+
+# With this option enabled ClamAV will try to detect phishing attempts by using
+# HTML.Phishing and Email.Phishing NDB signatures.
+# Default: yes
+#PhishingSignatures no
+
+# With this option enabled ClamAV will try to detect phishing attempts by
+# analyzing URLs found in emails using WDB and PDB signature databases.
+# Default: yes
+#PhishingScanURLs no
+
+
+##
+## Data Loss Prevention (DLP)
+##
+
+# Enable the DLP module
+# Default: No
+#StructuredDataDetection yes
+
+# This option sets the lowest number of Credit Card numbers found in a file
+# to generate a detect.
+# Default: 3
+#StructuredMinCreditCardCount 5
+
+# With this option enabled the DLP module will search for valid Credit Card
+# numbers only. Debit and Private Label cards will not be searched.
+# Default: no
+#StructuredCCOnly yes
+
+# This option sets the lowest number of Social Security Numbers found
+# in a file to generate a detect.
+# Default: 3
+#StructuredMinSSNCount 5
+
+# With this option enabled the DLP module will search for valid
+# SSNs formatted as xxx-yy-zzzz
+# Default: yes
+#StructuredSSNFormatNormal yes
+
+# With this option enabled the DLP module will search for valid
+# SSNs formatted as xxxyyzzzz
+# Default: no
+#StructuredSSNFormatStripped yes
+
+
+##
+## HTML
+##
+
+# Perform HTML normalisation and decryption of MS Script Encoder code.
+# Default: yes
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+#ScanHTML yes
+
+
+##
+## Archives
+##
+
+# ClamAV can scan within archives and compressed files.
+# If you turn off this option, the original files will still be scanned, but
+# without unpacking and additional processing.
+# Default: yes
+#ScanArchive yes
+
+
+##
+## Limits
+##
+
+# The options below protect your system against Denial of Service attacks
+# using archive bombs.
+
+# This option sets the maximum amount of time to a scan may take.
+# In this version, this field only affects the scan time of ZIP archives.
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result allow scanning
+# of certain files to lock up the scanning process/threads resulting in a
+# Denial of Service.
+# Time is in milliseconds.
+# Default: 120000
+#MaxScanTime 300000
+
+# This option sets the maximum amount of data to be scanned for each input
+# file. Archives and other containers are recursively extracted and scanned
+# up to this value.
+# Value of 0 disables the limit
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 100M
+#MaxScanSize 150M
+
+# Files larger than this limit won't be scanned. Affects the input file itself
+# as well as files contained inside it (when the input file is an archive, a
+# document or some other kind of container).
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 25M
+#MaxFileSize 30M
+
+# Nested archives are scanned recursively, e.g. if a Zip archive contains a RAR
+# file, all files within it will also be scanned. This options specifies how
+# deeply the process should be continued.
+# Note: setting this limit too high may result in severe damage to the system.
+# Default: 16
+#MaxRecursion 10
+
+# Number of files to be scanned within an archive, a document, or any other
+# container file.
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 10000
+#MaxFiles 15000
+
+# Maximum size of a file to check for embedded PE. Files larger than this value
+# will skip the additional analysis step.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 10M
+#MaxEmbeddedPE 10M
+
+# Maximum size of a HTML file to normalize. HTML files larger than this value
+# will not be normalized or scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 10M
+#MaxHTMLNormalize 10M
+
+# Maximum size of a normalized HTML file to scan. HTML files larger than this
+# value after normalization will not be scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 2M
+#MaxHTMLNoTags 2M
+
+# Maximum size of a script file to normalize. Script content larger than this
+# value will not be normalized or scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 5M
+#MaxScriptNormalize 5M
+
+# Maximum size of a ZIP file to reanalyze type recognition. ZIP files larger
+# than this value will skip the step to potentially reanalyze as PE.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 1M
+#MaxZipTypeRcg 1M
+
+# This option sets the maximum number of partitions of a raw disk image to be
+# scanned.
+# Raw disk images with more partitions than this value will have up to
+# the value number partitions scanned. Negative values are not allowed.
+# Note: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 50
+#MaxPartitions 128
+
+# This option sets the maximum number of icons within a PE to be scanned.
+# PE files with more icons than this value will have up to the value number
+# icons scanned.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 100
+#MaxIconsPE 200
+
+# This option sets the maximum recursive calls for HWP3 parsing during
+# scanning. HWP3 files using more than this limit will be terminated and
+# alert the user.
+# Scans will be unable to scan any HWP3 attachments if the recursive limit
+# is reached.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 16
+#MaxRecHWP3 16
+
+# This option sets the maximum calls to the PCRE match function during
+# an instance of regex matching.
+# Instances using more than this limit will be terminated and alert the user
+# but the scan will continue.
+# For more information on match_limit, see the PCRE documentation.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may severely impact performance.
+# Default: 100000
+#PCREMatchLimit 20000
+
+# This option sets the maximum recursive calls to the PCRE match function
+# during an instance of regex matching.
+# Instances using more than this limit will be terminated and alert the user
+# but the scan will continue.
+# For more information on match_limit_recursion, see the PCRE documentation.
+# Negative values are not allowed and values > PCREMatchLimit are superfluous.
+# WARNING: setting this limit too high may severely impact performance.
+# Default: 2000
+#PCRERecMatchLimit 10000
+
+# This option sets the maximum filesize for which PCRE subsigs will be
+# executed. Files exceeding this limit will not have PCRE subsigs executed
+# unless a subsig is encompassed to a smaller buffer.
+# Negative values are not allowed.
+# Setting this value to zero disables the limit.
+# WARNING: setting this limit too high or disabling it may severely impact
+# performance.
+# Default: 25M
+#PCREMaxFileSize 100M
+
+# When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, or
+# MaxRecursion limit will be flagged with the virus
+# "Heuristics.Limits.Exceeded".
+# Default: no
+#AlertExceedsMax yes
+
+##
+## On-access Scan Settings
+##
+
+# Don't scan files larger than OnAccessMaxFileSize
+# Value of 0 disables the limit.
+# Default: 5M
+#OnAccessMaxFileSize 10M
+
+# Max number of scanning threads to allocate to the OnAccess thread pool at
+# startup. These threads are the ones responsible for creating a connection
+# with the daemon and kicking off scanning after an event has been processed.
+# To prevent clamonacc from consuming all clamd's resources keep this lower
+# than clamd's max threads.
+# Default: 5
+#OnAccessMaxThreads 10
+
+# Max amount of time (in milliseconds) that the OnAccess client should spend
+# for every connect, send, and recieve attempt when communicating with clamd
+# via curl.
+# Default: 5000 (5 seconds)
+# OnAccessCurlTimeout 10000
+
+# Toggles dynamic directory determination. Allows for recursively watching
+# include paths.
+# Default: no
+#OnAccessDisableDDD yes
+
+# Set the include paths (all files inside them will be scanned). You can have
+# multiple OnAccessIncludePath directives but each directory must be added
+# in a separate line.
+# Default: disabled
+OnAccessIncludePath /data/
+OnAccessIncludePath /home/
+OnAccessIncludePath /tmp/
+OnAccessIncludePath /var/tmp/
+
+# Set the exclude paths. All subdirectories are also excluded.
+# Default: disabled
+#OnAccessExcludePath /home/user
+
+# Modifies fanotify blocking behaviour when handling permission events.
+# If off, fanotify will only notify if the file scanned is a virus,
+# and not perform any blocking.
+# Default: no
+OnAccessPrevention yes
+
+# When using prevention, if this option is turned on, any errors that occur
+# during scanning will result in the event attempt being denied. This could
+# potentially lead to unwanted system behaviour with certain configurations,
+# so the client defaults this to off and prefers allowing access events in
+# case of scan or connection error.
+# Default: no
+#OnAccessDenyOnError yes
+
+# Toggles extra scanning and notifications when a file or directory is
+# created or moved.
+# Requires the  DDD system to kick-off extra scans.
+# Default: no
+#OnAccessExtraScanning yes
+
+# Set the  mount point to be scanned. The mount point specified, or the mount
+# point containing the specified directory will be watched. If any directories
+# are specified, this option will preempt (disable and ignore all options
+# related to) the DDD system. This option will result in verdicts only.
+# Note that prevention is explicitly disallowed to prevent common, fatal
+# misconfigurations. (e.g. watching "/" with prevention on and no exclusions
+# made on vital system directories)
+# It can be used multiple times.
+# Default: disabled
+#OnAccessMountPath /
+#OnAccessMountPath /home/user
+
+# With this option you can whitelist the root UID (0). Processes run under
+# root with be able to access all files without triggering scans or
+# permission denied events.
+# Note that if clamd cannot check the uid of the process that generated an
+# on-access scan event (e.g., because OnAccessPrevention was not enabled, and
+# the process already exited), clamd will perform a scan.  Thus, setting
+# OnAccessExcludeRootUID is not *guaranteed* to prevent every access by the
+# root user from triggering a scan (unless OnAccessPrevention is enabled).
+# Default: no
+OnAccessExcludeRootUID yes
+
+# With this option you can whitelist specific UIDs. Processes with these UIDs
+# will be able to access all files without triggering scans or permission
+# denied events.
+# This option can be used multiple times (one per line).
+# Using a value of 0 on any line will disable this option entirely.
+# To whitelist the root UID (0) please enable the OnAccessExcludeRootUID
+# option.
+# Also note that if clamd cannot check the uid of the process that generated an
+# on-access scan event (e.g., because OnAccessPrevention was not enabled, and
+# the process already exited), clamd will perform a scan.  Thus, setting
+# OnAccessExcludeUID is not *guaranteed* to prevent every access by the
+# specified uid from triggering a scan (unless OnAccessPrevention is enabled).
+# Default: disabled
+#OnAccessExcludeUID -1
+
+# This option allows exclusions via user names when using the on-access
+# scanning client. It can be used multiple times.
+# It has the same potential race condition limitations of the
+# OnAccessExcludeUID option.
+# Default: disabled
+OnAccessExcludeUname clamscan
+
+# Number of times the OnAccess client will retry a failed scan due to
+# connection problems (or other issues).
+# Default: 0
+#OnAccessRetryAttempts 3
+
+##
+## Bytecode
+##
+
+# With this option enabled ClamAV will load bytecode from the database.
+# It is highly recommended you keep this option on, otherwise you'll miss
+# detections for many new viruses.
+# Default: yes
+#Bytecode yes
+
+# Set bytecode security level.
+# Possible values:
+#   None -      No security at all, meant for debugging.
+#               DO NOT USE THIS ON PRODUCTION SYSTEMS.
+#               This value is only available if clamav was built
+#               with --enable-debug!
+#   TrustSigned - Trust bytecode loaded from signed .c[lv]d files, insert
+#               runtime safety checks for bytecode loaded from other sources.
+#   Paranoid -  Don't trust any bytecode, insert runtime checks for all.
+# Recommended: TrustSigned, because bytecode in .cvd files already has these
+# checks.
+# Note that by default only signed bytecode is loaded, currently you can only
+# load unsigned bytecode in --enable-debug mode.
+#
+# Default: TrustSigned
+#BytecodeSecurity TrustSigned
+
+# Allow loading bytecode from outside digitally signed .c[lv]d files.
+# **Caution**: You should NEVER run bytecode signatures from untrusted sources.
+# Doing so may result in arbitrary code execution.
+# Default: no
+#BytecodeUnsigned yes
+
+# Set bytecode timeout in milliseconds.
+#
+# Default: 5000
+# BytecodeTimeout 1000
+

--- a/clamav/vars/main.yml
+++ b/clamav/vars/main.yml
@@ -1,0 +1,2 @@
+---
+aws_region: us-east-1


### PR DESCRIPTION
This role was created to support a customer requirement to install/configure ClamAV Linux virus scanning software on all instances.  It is generic enough that I felt it would be a good candidate for the shared ansible roles in case other programs have this requirement in the future.  This role will do the following:

- Install the extra (epel) clamav related packages including amazon-linux-extras, clamav, clamav-update, and clamd
- Configure daemon log directories
- Configure virus updates to pull automatically via freshclam service
- Enable ClamAV base and OnAccess Scanning daemons
- Enable integration with Cloudwatch via cron/shell scripts that interface with AWS via the aws-cli tools