### PR TITLE
Making 10 hour session termination

### DIFF
--- a/nist_compliance/templates/sshd_config.j2
+++ b/nist_compliance/templates/sshd_config.j2
@@ -125,7 +125,7 @@ X11Forwarding yes
 Banner /etc/issue.net
 #AddressFamily inet
 ClientAliveInterval 300
-ClientAliveCountMax 0
+ClientAliveCountMax 120
 PermitEmptyPasswords no
 PermitUserEnvironment no
 Ciphers aes128-ctr,aes192-ctr,aes256-ctr


### PR DESCRIPTION
We have a requirement from our security team to terminate ssh session after a max of 10 hours. It is my understanding that in order to do this you multiple the ClientAliveInterval (in seconds) by the ClientAliveCountMax. So in this case 300 seconds x 120 is 10 hours.