### PR TITLE
Updating auditd rules for compliance

### DIFF
--- a/nist_compliance/templates/rulesd_compliance.rules.j2
+++ b/nist_compliance/templates/rulesd_compliance.rules.j2
@@ -14,32 +14,8 @@
 -a exit,never -F auid>2147483645
 -a exit,never -F auid!=0 -F auid<500
 
-##
-## Security Scan Items: ##
-##
--w /usr/bin/yum -p wa
--w /usr/sbin/rpm -p wa
--w /var/log/btmp -p wa -k session
--w /var/log/wtmp -p wa -k session
--w /var/run/utmp -p wa -k session
--w /sbin/insmod -p x
--w /sbin/modprobe -p x
--w /sbin/rmmod -p x
-
 -a always,exit -F path=/usr/bin/curl -F perm=x -F auid>=500 -F auid!=4294967295 -k retrieve_url
 -a always,exit -F path=/usr/bin/wget -F perm=x -F auid>=500 -F auid!=4294967295 -k retrieve_url
-
-## Time stuff
--a always,exit -F arch=b64 -S adjtimex -S settimeofday -S clock_settime -k SYS_audit_time_rules
--a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex -S clock_settime -S settimeofday -k SYS_audit_time_rules
--w /etc/localtime -p wa -k time-change
-
-## System Locale
--a always,exit -F arch=b64 -S sethostname -k SYS_system-locale
--a always,exit -F arch=b64 -S setdomainname -k SYS_system-locale
--a always,exit -F arch=b32 -S sethostname -k SYS_system-locale
--a always,exit -F arch=b32 -S setdomainname -k SYS_system-locale
 
 ## Unsuccessful creation
 -a always,exit -F arch=b64 -S creat -S mkdir -S mknod -S link -S symlink -F exit=-EACCES -k SYS_creation
@@ -78,35 +54,12 @@
 ## Mount options
 -a always,exit -F arch=b32 -S mount -S umount2 -k SYS_mount
 
-## Permissions auditing
--a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -k SYS_perm_mod
--a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -k SYS_perm_mod
--a always,exit -F arch=b64 -S chown -S setxattr -S fsetxattr -S removexattr -S fremovexattr -F auid>=500 -k perm_mod
--a always,exit -F arch=b64 -S chown -S lsetxattr -S lremovexattr -F auid>=500 -k perm_mod
--a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -k SYS_perm_mod
--a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -k SYS_perm_mod
--a always,exit -F arch=b32 -S chown -S setxattr -S fsetxattr -S removexattr -S fremovexattr -F auid>=500 -k perm_mod
--a always,exit -F arch=b32 -S chown -S lsetxattr -S lremovexattr -F auid>=500 -k perm_mod
-
-## Other items required by security scan
--a always,exit -F arch=b64 -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S init_module -S delete_module -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S init_module -S delete_module -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S init_module -S delete_module -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S init_module -S delete_module -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
-
 ## Execution of executables
 -a always,exit -F arch=b32 -S execve -k executables
 -a always,exit -F arch=b64 -S execve -k executables
 
 ## Privileged access
--w /etc/sudoers.d/ -p wa -k privileged_access
--w /bin/su -p x -k privileged_access
 -w /usr/bin/sudo -p x -k privileged_access
--w /etc/sudoers -p rw -k privileged_access
 -a always,exit -F arch=b64 -S execve -F euid=0 -F auid>=1000 -F auid!=-1 -F auid!=4294967295 -k privileged_access
 -a always,exit -F arch=b32 -S execve -F euid=0 -F auid>=1000 -F auid!=-1 -F auid!=4294967295 -k privileged_access
 -a exit,always -F arch=b64 -F euid=0 -S execve -k privileged_access
@@ -168,9 +121,160 @@
 -a exit,always -F arch=b32 -S execve -F path=/sbin/pwsh -k powershell
 -a exit,always -F arch=b64 -S execve -F path=/sbin/pwsh -k powershell
 
+## Privileged passwd commands
+-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+
+# Privileged priv change
+-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+
+# Privileged mount
+-a always,exit -F path=/usr/bin/umount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+
+# Privileged postfix
+-a always,exit -F path=/usr/sbin/postdrop -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+
+# Privileged ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
+
+# Privileged cron
+-a always,exit -F path=/usr/bin/crontab -F auid>=1000 -F auid!=4294967295 -k privileged-cron
+
+# Privileged pam
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid>=1000 -F auid!=4294967295 -k privileged-pam 
+
+# Module change
+-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change
+-a always,exit -F arch=b32 -S create_module -k module-change
+-a always,exit -F arch=b64 -S create_module -k module-change
+-a always,exit -F arch=b32 -S finit_module -k module-change
+-a always,exit -F arch=b64 -S finit_module -k module-change
+
+# rmdir syscall
+-a always,exit -F arch=b32 -S rmdir -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S rmdir -F auid>=1000 -F auid!=4294967295 -k delete
+
+# unlink syscall
+-a always,exit -F arch=b64 -S unlink -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -F auid>=1000 -F auid!=4294967295 -k delete
+
+# unlinkat syscall
+-a always,exit -F arch=b32 -S unlinkat -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=4294967295 -k delete
+
+# Audit time rules
+-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+-a always,exit -F arch=b64 -S clock_settime -k time-change
+-a always,exit -F arch=b32 -S clock_settime -k time-change
+-w /etc/localtime -p wa -k time-change
+
+# Identity
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/security/opasswd -p wa -k identity
+
+## System Locale
+-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
+-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+-w /etc/issue -p wa -k system-locale
+-w /etc/issue.net -p wa -k system-locale
+-w /etc/hosts -p wa -k system-locale
+-w /etc/sysconfig/network -p wa -k system-locale
+-w /etc/sysconfig/network-scripts/ -p wa -k system-locale
+
+# SELinux
+-w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
+
+# Login events
+-w /var/log/lastlog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
+-w /var/run/utmp -p wa -k session
+-w /var/log/wtmp -p wa -k logins
+-w /var/log/btmp -p wa -k logins
+
+## Permissions auditing
+-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+
+## Access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S init_module -S delete_module -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S init_module -S delete_module -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S init_module -S delete_module -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S init_module -S delete_module -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+
+## Privileged Commands
+-a always,exit -F path=/usr/bin/staprun -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/sbin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+
+## Mounts
+-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+
+## Delete
+-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
+
+## Scope
+-w /etc/sudoers -p wa -k scope
+-w /etc/sudoers.d/ -p wa -k scope
+
+## Actions
+-w /var/log/sudo.log -p wa -k actions
+
+## Modules
+-w /usr/bin/yum -p wa
+-w /usr/sbin/rpm -p wa
+-w /sbin/insmod -p x -k modules
+-w /sbin/modprobe -p x -k modules
+-w /sbin/rmmod -p x -k modules
+-a always,exit -F arch=b64 -S init_module -S delete_module -k modules
+-a always,exit -F arch=b32 -S init_module -S delete_module -k modules
+
+## setgid
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid
 
 ## Once you enable the following line, auditd can no longer be shut down or modified
 ## without a reboot. Make sure your rules are the way you want them before enabling
 ## this.
 
-# -e 2
+#-e 2


### PR DESCRIPTION
As part of the CHEX ATO we did an overhaul of the compliance rules to clear some new findings on our Nessus scans.  To test apply the role and:

NOTE:  You can use auditctl with the -l (list) and/or -R (read) options on /etc/audit/rules.d/compliance.rules if you wish to test the new compliance rules prior to restarting auditd
- service auditd restart     (or systemctl reload auditd)
- systemctl status auditd   (verify service successfully restarted and no errors are listed for augenrules or otherwise)
- Verify that expected events are being logged to /var/log/audit/audit.log with the correct keys
- Optional:  Generate security scan on the applied box to make sure no new or unexpected findings are generated as a result of these changes

This is a low priority change so if there are concerns importing this at the moment due to ongoing ATO efforts on any of the teams we can leave this PR open until those tasks are complete.  If possible would like to get approval from a member of each of the teams before merge.