### PR TITLE
Adding lines to /etc/pam.d/sshd for wheel group

### DIFF
--- a/nist_compliance/defaults/main.yml
+++ b/nist_compliance/defaults/main.yml
@@ -5,3 +5,5 @@ required_vars:
   - compliance_ntp_servers
   - compliance_team_repo_name
   - compliance_users
+
+compliance_pam_umask: "0027"

--- a/nist_compliance/tasks/amazon_linux_2.yml
+++ b/nist_compliance/tasks/amazon_linux_2.yml
@@ -225,6 +225,13 @@
   lineinfile:
     dest: /etc/pam.d/su
     line: "auth           required        pam_wheel.so use_uid"
+  tags: [ compliance, pamd ]
+
+- name: Adding lines to /etc/pam.d/sshd for wheel group
+  lineinfile:
+    dest: /etc/pam.d/sshd
+    line: "session    optional     pam_umask.so umask={{ compliance_pam_umask }}"
+  tags: [ compliance, pamd, umask ]
 
 - name: Check for /etc/bashrc
   stat:


### PR DESCRIPTION
Rapid7 was dinging us for using umask 0022 and it appears that updating the /etc/pam.d/sshd file cleans up the vulnerability. I wanted to still leave the default as 0027 (which is what it is setting in other file) and allow anyone to just override it with a different value, if needed.