### PR TITLE
<fix> Add console to securetty

### DIFF
--- a/nist_compliance/tasks/amazon_linux_2.yml
+++ b/nist_compliance/tasks/amazon_linux_2.yml
@@ -165,11 +165,11 @@
   when: dbus_daemon.stat.exists == true
   tags: [ compliance, dbus ]
 
-- name: Remove anything but tty or vc/ from /etc/securetty
+- name: Prevent anonymous login through /etc/securetty
   lineinfile:
     dest: /etc/securetty
     state: absent
-    regexp: '^(?!tty[0-9]+|vc\/[0-9]+).*$'
+    regexp: '^(?!(^console|^tty[0-9]+|^vc\/[0-9]+)).*$'
   tags: [ compliance, securetty ]
 
 - name: Ensure /etc/sysconfig/init has SINGLE=/sbin/sulogin


### PR DESCRIPTION
Resolves FH-3436. This commit changes the regex for preventing
anonymous root login to include console.