### PR TITLE
FH-3735: Fix compliance rules

### DIFF
--- a/nist_compliance/tasks/amazon_linux_2.yml
+++ b/nist_compliance/tasks/amazon_linux_2.yml
@@ -684,10 +684,9 @@
 
 - name: Ensure permissions on all log files are configured
   file:
-    path: "{{ item.path }}"
+    path: "/var/log"
     mode: "g-wx,o-rwx"
-  when: var_log_files.matched > 0
-  with_items: "{{ var_log_files.files }}"
+    recurse: yes
   tags: [ compliance, umask, varlog ]
 
 - name: Set default user acl permissions for log file directories

--- a/nist_compliance/tasks/amazon_linux_2.yml
+++ b/nist_compliance/tasks/amazon_linux_2.yml
@@ -674,19 +674,12 @@
     mode: 0600
   tags: [ compliance, grub, umask ]
 
-- name: Gather /var/log/ file list
-  find:
-    paths: 
-      - /var/log/
-    recurse: yes
-  register: var_log_files
-  tags: [ compliance, umask, varlog ]
-
 - name: Ensure permissions on all log files are configured
   file:
     path: "/var/log"
     mode: "g-wx,o-rwx"
     recurse: yes
+  ignore_errors: True
   tags: [ compliance, umask, varlog ]
 
 - name: Set default user acl permissions for log file directories


### PR DESCRIPTION
**Changes**
* Instead of changing permissions one file at a time, the entire /var/log permissions are now set on the folder level recursively

**TODO**
* `/etc/securetty` is still not correct according to Rapid7. The rule to fix this does exist, but it doesn't seem to work the way we think it should work